### PR TITLE
Tweaks to pp.check

### DIFF
--- a/R/ppcheck.R
+++ b/R/ppcheck.R
@@ -1,11 +1,15 @@
 
-pp.check <- function(x, observed, simulated, xlab=NULL, ylab=NULL, main=NULL){
+pp.check <- function(x, observed, simulated, xlab=NULL, ylab=NULL, main=NULL, ...){
   if(class(x)!="jagsUI"){stop('Requires jagsUI object as input')}
   devAskNewPage(ask=FALSE)
-  observed <- eval(parse(text=paste('x$sims.list$',observed,sep="")))
-  simulated <- eval(parse(text=paste('x$sims.list$',simulated,sep="")))
-  
-  bpval <- mean(simulated>observed)
+  obs <- eval(parse(text=paste('x$sims.list$',observed,sep="")))
+  if(is.null(obs))
+    stop("MCMC chain ", deparse(substitute(observed)), " not found.", call.=FALSE)
+  sim <- eval(parse(text=paste('x$sims.list$',simulated,sep="")))
+  if(is.null(sim))
+    stop("MCMC chain ", deparse(substitute(siomulated)), " not found.", call.=FALSE)
+
+    bpval <- mean(sim > obs)
 
   if(is.null(xlab)){
     xlab <- 'Observed Data'
@@ -13,18 +17,26 @@ pp.check <- function(x, observed, simulated, xlab=NULL, ylab=NULL, main=NULL){
   if(is.null(ylab)){
     ylab <- 'Simulated Data'
   }
+  usermain <- main
   if(is.null(main)){
     main <- paste('Posterior Predictive Check','\n',
                   'Bayesian P-value =',round(bpval,2))
   }
 
-  minval <- min(c(observed,simulated))
-  maxval <- max(c(observed,simulated))
-  plotrange <- c(minval,maxval)
-  
-  plot(x = observed, y = simulated, xlab=xlab, ylab=ylab, main=main, 
-       xlim=plotrange,ylim=plotrange)
-  abline(1,1)
-  
+  # minval <- min(c(observed,simulated))
+  # maxval <- max(c(observed,simulated))
+  # plotrange <- c(minval,maxval)
+  plotrange <- range(obs, sim)
 
+  plot(x = obs, y = sim, xlab=xlab, ylab=ylab, main=main,
+       xlim=plotrange,ylim=plotrange, ...)
+  # abline(1,1)
+  abline(0,1, lwd=2)
+  if(!is.null(usermain)) {
+    where <- if(bpval < 0.5) 'topleft' else 'bottomright'
+    graphics::legend(where, paste("P =", round(bpval,2)), bty='n', cex=1.5)
+  }
+
+  return(bpval)
 }
+

--- a/man/ppcheck.Rd
+++ b/man/ppcheck.Rd
@@ -5,7 +5,7 @@
 \title{Posterior Predictive Checks for Bayesian Analyses fit in JAGS}
 
 \usage{
-  pp.check(x, observed, simulated, xlab=NULL, ylab=NULL, main=NULL)}
+  pp.check(x, observed, simulated, xlab=NULL, ylab=NULL, main=NULL, ...)}
 
 \arguments{
   \item{x}{A jagsUI object generated using the \code{jags} function}
@@ -14,6 +14,7 @@
   \item{xlab}{Customize x-axis label}
   \item{ylab}{Customize y-axis label}
   \item{main}{Customize plot title}
+  \item{\dots}{Additional arguments passed to \link{plot.default}}
 }
 
 \description{


### PR DESCRIPTION
A few tweaks to the new pp.check:
1) Sensible error messages if names of observed and simulated are incorrect (mis-typed), otherwise you get `'x' and 'y' lengths differ`.
2) Function returns the P-value.
3) For used specified `main`, the P-value appears in a corner of the plot.
