### PR TITLE
Tweaks to plotting functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: jagsUI
-Version: 1.5.1.9018
-Date: 2019-12-12
+Version: 1.5.1.9019
+Date: 2019-12-14
 Title: A Wrapper Around 'rjags' to Streamline 'JAGS' Analyses
 Author: Ken Kellner <contact@kenkellner.com>
 Maintainer: Ken Kellner <contact@kenkellner.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: jagsUI
-Version: 1.5.1.9019
-Date: 2019-12-14
+Version: 1.5.1.9020
+Date: 2019-12-26
 Title: A Wrapper Around 'rjags' to Streamline 'JAGS' Analyses
 Author: Ken Kellner <contact@kenkellner.com>
 Maintainer: Ken Kellner <contact@kenkellner.com>
@@ -21,7 +21,7 @@ Suggests:
     testthat,
     vdiffr
 SystemRequirements: JAGS (http://mcmc-jags.sourceforge.net)
-Description: A set of wrappers around 'rjags' functions to run Bayesian analyses in 'JAGS' (specifically, via 'libjags').  A single function call can control adaptive, burn-in, and sampling MCMC phases, with MCMC chains run in sequence or in parallel. Posterior distributions are automatically summarized (with the ability to exclude some monitored nodes if desired) and functions are available to generate figures based on the posteriors (e.g., predictive check plots, traceplots). Function inputs, argument syntax, and output format are nearly identical to the 'R2WinBUGS'/'R2OpenBUGS' packages to allow easy switching between MCMC samplers. 
+Description: A set of wrappers around 'rjags' functions to run Bayesian analyses in 'JAGS' (specifically, via 'libjags').  A single function call can control adaptive, burn-in, and sampling MCMC phases, with MCMC chains run in sequence or in parallel. Posterior distributions are automatically summarized (with the ability to exclude some monitored nodes if desired) and functions are available to generate figures based on the posteriors (e.g., predictive check plots, traceplots). Function inputs, argument syntax, and output format are nearly identical to the 'R2WinBUGS'/'R2OpenBUGS' packages to allow easy switching between MCMC samplers.
 License: GPL-3
 URL: https://github.com/kenkellner/jagsUI
 NeedsCompilation: no

--- a/R/densityplot.R
+++ b/R/densityplot.R
@@ -1,14 +1,15 @@
 #Get density plots for series of parameters
-densityplot <- function(x, parameters=NULL, per_plot=9, ask=grDevices::dev.interactive(orNone = TRUE)){
+densityplot <- function(x, parameters=NULL, per_plot=9, ask=NULL){
   
   #Check input class and get basic plot settings
   check_class(x)  
+  if(is.null(ask))
+    ask <- grDevices::dev.interactive(orNone = TRUE)
   plot_info <- get_plot_info(x, parameters, per_plot, ask)
   
   #Handle par()
-  old_par <- graphics::par(no.readonly=TRUE)
+  old_par <- graphics::par(plot_info$new_par)
   on.exit(graphics::par(old_par))  
-  graphics::par(plot_info$new_par)
   
   #Generate plot
   n <- length(plot_info$params)

--- a/R/plot.R
+++ b/R/plot.R
@@ -6,7 +6,7 @@ plot.jagsUI <- function(x, parameters=NULL, per_plot=4, ask=grDevices::dev.inter
     ask <- grDevices::dev.interactive(orNone = TRUE)
   plot_info <- get_plot_info(x, parameters, per_plot, ask)
   dims <- c(min(length(plot_info$params), per_plot), 2)
-  if(length(plot_info$params) < per_plot) ask <- FALSE
+  if(length(plot_info$params) <= per_plot) ask <- FALSE
   new_par <- list(mfrow = dims, mar = c(4,4,2.5,1), oma=c(0,0,0,0), ask=ask)
    
   #Handle par()

--- a/R/plot.R
+++ b/R/plot.R
@@ -2,15 +2,17 @@
 #Plot method for jagsUI objects
 plot.jagsUI <- function(x, parameters=NULL, per_plot=4, ask=grDevices::dev.interactive(orNone = TRUE), ...){
 
+  if(is.null(ask))
+    ask <- grDevices::dev.interactive(orNone = TRUE)
   plot_info <- get_plot_info(x, parameters, per_plot, ask)
   dims <- c(min(length(plot_info$params), per_plot), 2)
   if(length(plot_info$params) < per_plot) ask <- FALSE
   new_par <- list(mfrow = dims, mar = c(4,4,2.5,1), oma=c(0,0,0,0), ask=ask)
    
   #Handle par()
-  old_par <- graphics::par(no.readonly=TRUE)
+  old_par <- graphics::par(new_par)
   on.exit(graphics::par(old_par))  
-  graphics::par(new_par)
+  
 
   #Make plot
   for (i in plot_info$params){

--- a/R/traceplot.R
+++ b/R/traceplot.R
@@ -1,15 +1,16 @@
 #Get traceplots for series of parameters
 traceplot <- function(x, parameters=NULL, Rhat_min=NULL,
-                      per_plot=9, ask=grDevices::dev.interactive(orNone = TRUE)){
+                      per_plot=9, ask=NULL){
 
   #Check input class and get basic plot settings
   check_class(x)
+  if(is.null(ask))
+    ask <- grDevices::dev.interactive(orNone = TRUE)
   plot_info <- get_plot_info(x, parameters, per_plot, ask, Rhat_min)
 
   #Handle par()
-  old_par <- graphics::par(no.readonly=TRUE)
+  old_par <- graphics::par(plot_info$new_par)
   on.exit(graphics::par(old_par))
-  graphics::par(plot_info$new_par)
 
   #Generate plot
   n <- length(plot_info$params)
@@ -73,9 +74,9 @@ get_plot_info <- function(x, parameters, per_plot, ask, Rhat_min=NULL){
   }
 
   #Set up new par settings
-  dims <- c(ceiling(sqrt(per_plot)), round(sqrt(per_plot)))
-  new_par <- list(mfrow=dims, mar=c(1.5,1.5,2.5,1), oma=c(3,3,0,0),
-                ask=ask)
+  new_par <- list(mar=c(1.5,1.5,2.5,1), oma=c(3,3,0,0), ask=ask)
+  if(per_plot > 1)
+    new_par$mfrow <- c(ceiling(sqrt(per_plot)), round(sqrt(per_plot)))
 
   list(params=parameters, new_par=new_par, per_plot=per_plot)
 }

--- a/R/traceplot.R
+++ b/R/traceplot.R
@@ -30,10 +30,13 @@ param_trace <- function(x, parameter, m_labels=FALSE){
 
   #Draw plot
   cols <- grDevices::rainbow(ncol(vals))
-  graphics::plot(1:nrow(vals), vals[,1], type='l', col=cols[1],
-                 ylim=range(vals), xlab='Iterations', ylab='Value',
+  graphics::matplot(1:nrow(vals), vals, type='l', lty=1, col=cols,
+                 xlab='Iterations', ylab='Value',
                  main=paste('Trace of',parameter))
-  for (i in 2:ncol(vals)) graphics::lines(1:nrow(vals), vals[,i], col=cols[i])
+  # graphics::plot(1:nrow(vals), vals[,1], type='l', col=cols[1],
+                 # ylim=range(vals), xlab='Iterations', ylab='Value',
+                 # main=paste('Trace of',parameter))
+  # for (i in 2:ncol(vals)) graphics::lines(1:nrow(vals), vals[,i], col=cols[i]) # this fails with 1 chain
 
   #Add Rhat value
   graphics::legend('bottomright', legend=bquote(hat(R) == .(Rhat)),

--- a/man/densityplot.Rd
+++ b/man/densityplot.Rd
@@ -4,15 +4,14 @@
 \title{Density plots of JAGS output}
 
 \usage{
-  densityplot(x, parameters=NULL, per_plot=9,
-              ask=grDevices::dev.interactive(orNone = TRUE))
+  densityplot(x, parameters=NULL, per_plot=9, ask=NULL)
 }
 
 \arguments{
   \item{x}{A jagsUI object}
   \item{parameters}{A vector of names (as characters) of parameters to plot. Parameter names must match parameters included in the model. Calling non-scalar parameters without subsetting (e.g. \code{alpha}) will plot all values of \code{alpha}. If \code{parameters=NULL}, all parameters will be plotted.}
   \item{per_plot}{Maximum number of parameters to include on each plot.}
-  \item{ask}{If \code{TRUE}, ask user for confirmation before generating each new plot; the default is to ask if output is going to the screen.}
+  \item{ask}{If \code{TRUE}, ask user for confirmation before generating each new plot; the default is to ask when output is going to the screen, not when it is going to a file.}
 }
 
 \description{

--- a/man/traceplot.Rd
+++ b/man/traceplot.Rd
@@ -4,8 +4,7 @@
 \title{Traceplots of JAGS output}
 
 \usage{
-  traceplot(x, parameters=NULL, Rhat_min=NULL, per_plot=9,
-            ask=grDevices::dev.interactive(orNone = TRUE))
+  traceplot(x, parameters=NULL, Rhat_min=NULL, per_plot=9, ask=NULL)
 }
 
 \arguments{
@@ -13,7 +12,7 @@
   \item{parameters}{A vector of names (as characters) of parameters to plot. Parameter names must match parameters included in the model. Calling non-scalar parameters without subsetting (e.g. \code{alpha}) will plot all values of \code{alpha}. If \code{parameters=NULL}, all parameters will be plotted.}
   \item{Rhat_min}{If provided, only plot parameters with Rhat values that exceed the provided value. A good min value to start with is 1.05.}
   \item{per_plot}{Maximum number of parameters to include on each plot.}
-  \item{ask}{If \code{TRUE}, ask user for confirmation before generating each new plot; the default is to ask if output is going to the screen.}
+  \item{ask}{If \code{TRUE}, ask user for confirmation before generating each new plot; the default is to ask when output is going to the screen, not when it is going to a file.}
 }
 
 \description{


### PR DESCRIPTION
args list now has `ask=NULL` but same behaviour. `traceplot` and `densityplot` do not touch `par(mfrow...)` when `per_plot=1`. Only par settings which have been changes are restored.

Ran the example in `shinyjags` and plots seem to  be well-behaved.