### PR TITLE
Fix bug in update.jagsUI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: jagsUI
-Version: 1.5.1.9100
-Date: 2020-10-07
+Version: 1.5.1.9101
+Date: 2021-01-31
 Title: A Wrapper Around 'rjags' to Streamline 'JAGS' Analyses
 Author: Ken Kellner <contact@kenkellner.com>
 Maintainer: Ken Kellner <contact@kenkellner.com>

--- a/R/update.R
+++ b/R/update.R
@@ -53,7 +53,15 @@ update.jagsUI <- function(object, parameters.to.save=NULL, n.adapt=NULL, n.iter,
     
   #Run process output
   output <- process.output(samples,DIC=DIC,codaOnly,verbose=verbose)
-    
+  if(is.null(output)){
+    output <- list()
+    output$samples <- samples
+    output$model <- m
+    output$n.cores <- object$mcmc.info$n.cores
+    class(output) <- 'jagsUIbasic'
+    return(output)
+  }
+ 
   #Summary
   output$summary <- summary.matrix(output,samples,object$mcmc.info$n.chains,codaOnly)
   


### PR DESCRIPTION
When processing output and running out of memory ("cannot allocate vector..." error), `update.jagsUI` should fall back to class `jagsUIbasic`, but code to catch the NULL output from `process.output` was not there. Now added.