### PR TITLE
Reproducible output with parallel=FALSE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: jagsUI
-Version: 1.5.1.9101
-Date: 2021-01-31
+Version: 1.5.1.9102
+Date: 2021-05-23
 Title: A Wrapper Around 'rjags' to Streamline 'JAGS' Analyses
 Author: Ken Kellner <contact@kenkellner.com>
 Maintainer: Ken Kellner <contact@kenkellner.com>

--- a/R/geninits.R
+++ b/R/geninits.R
@@ -67,7 +67,8 @@ gen.inits <- function(inits,n.chains,seed,parallel){
     needs.RNG <- is.null(init.values)|!other.RNG
     
     #If parallel and no custom RNG has been set, add one. Otherwise all chains will start with same seed.
-    if(needs.RNG&parallel){
+    # if(needs.RNG&parallel){
+    if(needs.RNG){
       
       init.rand <- floor(runif(n.chains,1,100000))
       


### PR DESCRIPTION
Currently `jags` does not give reproducible output with `parallel=FALSE` while `seed=NULL`, ie, you can't get reproducible output by calling `set.seed` before `jags`. Here's a bit of code to show the problem:
````
example(jags)  # set up everything for the example

set.seed(42)
out1 <- jags(data, inits, params, modfile, n.chains = 3, n.iter = 1000)

set.seed(42)
out2 <- jags(data, inits, params, modfile, n.chains = 3, n.iter = 1000)

all.equal(out1$samples, out2$samples)  # not the same
````

With `parallel=TRUE` it's ok. Same with `jags.basic`. The difference is due to `& parallel` in line 70 of the "geninits.R" file. Functions in the `rjags` package ignore the seed set in R, so to get reproducible results a seed needs to be passed in `inits` for serial as well as parallel. Deleting `& parallel` fixes this.

I've tested this with R CMD check on R 4.1.0 and R devel (build r80301) a few days ago and ran all the AHM code with the new version in R devel and some chapters in R 4.1.0 as well. I got the latest R devel this morning (build r80354) and got an error installing `jagsUI` as it can't find DLL `rjags`: an issue with R devel I guess.
