### PR TITLE
Fixes for JAGS 5.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Imports:
     graphics,
     grDevices,
     parallel,
-    rjags (>= 3-13),
+    rjags (>= 4-17),
     stats,
     utils
 Suggests: knitr, markdown, tinytest

--- a/R/run_rjags.R
+++ b/R/run_rjags.R
@@ -281,7 +281,13 @@ set.factories <- function(factories){
 set.modules <- function(modules,DIC){
 
   #Load/unload appropriate modules (besides dic)
-  called.set <- c('basemod','bugs',modules)
+
+  default.set <- c('basemod', 'bugs')
+  if (rjags::jags.version() >= as.numeric_version("5")) {
+     #deviance monitor moved to the 'diag' module so load by default
+     default.set <- c(default.set, 'diag')
+  }
+  called.set <-  c(default.set, modules)
   current.set <- rjags::list.modules()
 
   load.set <- called.set[!called.set%in%current.set]

--- a/inst/tinytest/test_autojags.R
+++ b/inst/tinytest/test_autojags.R
@@ -71,10 +71,19 @@ nul <- capture.output(
 
 # Runs three updates of 10 iterations each
 expect_true(grepl("Note: ALL iterations", nul[6]))
-expect_true(grepl("Update 3", nul[10]))
-expect_true(nul[11] == "")
-# All are combined to yield 30 total iterations in each chain
-expect_equal(coda::niter(out$samples), 30)
+if (rjags::jags.version() >= as.numeric_version("5")) {
+  expect_true(grepl("Update 2", nul[9]))
+  expect_true(nul[10] == "")
+  # All are combined to yield 20 total iterations in each chain
+  expect_equal(coda::niter(out$samples), 20)
+
+} else {
+  expect_true(grepl("Update 3", nul[10]))
+  expect_true(nul[11] == "")
+  # All are combined to yield 30 total iterations in each chain
+  expect_equal(coda::niter(out$samples), 30)
+}
+
 
 if(at_home){
   ref <- readRDS("autojags_ref_alliter.Rds")

--- a/inst/tinytest/test_run_rjags.R
+++ b/inst/tinytest/test_run_rjags.R
@@ -1,22 +1,28 @@
 # load_modules loads and unloads correctly
-jagsUI:::set.modules(NULL, FALSE)
-expect_equal(rjags::list.modules(),c('basemod','bugs'))
-jagsUI:::set.modules('glm', FALSE)
-expect_equal(rjags::list.modules(),c('basemod','bugs','glm'))
-jagsUI:::set.modules(NULL, FALSE)
-expect_equal(rjags::list.modules(),c('basemod','bugs'))
-jagsUI:::set.modules(NULL, DIC=TRUE)
-expect_equal(rjags::list.modules(),c('basemod','bugs','dic'))
 
+if (rjags::jags.version() < as.numeric_version("5")) {
+    default.modules <- c('basemod','bugs')
+    test.factories <- 1:2
+} else {
+    default.modules <- c('basemod','bugs','diag') # diag provides deviance monitor
+    test.factories <- c(6,1) # change in precedence of bugs::binomSlice factory
+}
+
+jagsUI:::set.modules(NULL, FALSE)
+expect_equal(rjags::list.modules(),default.modules)
+jagsUI:::set.modules('glm', FALSE)
+expect_equal(rjags::list.modules(),c(default.modules,'glm'))
+jagsUI:::set.modules(NULL, FALSE)
+expect_equal(rjags::list.modules(),default.modules)
+jagsUI:::set.modules(NULL, DIC=TRUE)
+expect_equal(rjags::list.modules(),c(default.modules,'dic'))
 
 # load_factories works correctly
 jagsUI:::set.factories(NULL)
-expect_equal(rjags::list.factories('sampler')[1:2,2], c(TRUE, TRUE))
-jagsUI:::set.factories(c('bugs::BinomSlice sampler FALSE',
-                                   'bugs::RW1 sampler FALSE'))
-expect_equal(rjags::list.factories('sampler')[1:2,2], c(FALSE, FALSE))
-jagsUI:::set.factories(c('bugs::BinomSlice sampler TRUE',
-                                   'bugs::RW1 sampler TRUE'))
-expect_equal(rjags::list.factories('sampler')[1:2,2], c(TRUE, TRUE))
+expect_equal(rjags::list.factories('sampler')[test.factories,2], c(TRUE, TRUE))
+jagsUI:::set.factories(c('bugs::BinomSlice sampler FALSE', 'bugs::RW1 sampler FALSE'))
+expect_equal(rjags::list.factories('sampler')[test.factories,2], c(FALSE, FALSE))
+jagsUI:::set.factories(c('bugs::BinomSlice sampler TRUE', 'bugs::RW1 sampler TRUE'))
+expect_equal(rjags::list.factories('sampler')[test.factories,2], c(TRUE, TRUE))
 expect_error(jagsUI:::set.factories(c('bad bad')))
 expect_error(jagsUI:::set.factories(c('bugs::fake sampler FALSE')))


### PR DESCRIPTION
With the forthcoming release of JAGS 5.0.0 I am testing CRAN packages to make sure they will still work with the new release. The jagsUI package is one of the main interfaces to JAGS from R and is a high priority. This pull request fixes issues with JAGS 5.0.0 and is back-compatible so that jagsUI still works with the current release version of JAGS and rjags.

The main change for jagsUI is that likelihood-based diagnostics have been moved into the new `diag` module. The `dic` module still exists as a stub. It is harmless to load and unload it in JAGS 5.0.0 but also it does nothing. In rjags_5-1 (not yet on CRAN), and also the command line interface to JAGS 5.0.0, the `diag` module is loaded by default. My recommendation is that you do the same for jagsUI. The main reason for this (apart from diagnostics being very important) is that users have become used to setting a monitor for "deviance" without loading any additional modules. This monitor is now in the `diag` module so default loading of `diag` maintains backwards compatible behaviour. The `diag` module contains no functions, distributions, or samplers, so does not affect modelling.

Another minor change is that the precedence of the `bugs::BinomSlice` factory has changed and this required modifications to one of the tests.

The test of autojags terminates more quickly with JAGS 5 so I also had to change this test. I think this test is quite fragile as I cannot guarantee stable behaviour across versons of JAGS.

I am using `rjags::jags.version` to detect the version of the JAGS library and make conditional changes to the code. This preserves back-compatibility with JAGS 4. Since `jags.version` was introduced with rjags version 4 this means the patched jagsUI package is no longer compatible with JAGS 3 so I have bumped the minimum rjags version in the DESCRIPTION file.

Thank you for all your work providing a user-friendly interface to JAGS.